### PR TITLE
change prefix for SOTS 2019 to SOTS19

### DIFF
--- a/scripts/pivotal-listener.coffee
+++ b/scripts/pivotal-listener.coffee
@@ -44,7 +44,7 @@ module.exports = (robot) ->
         "Salesforce": "SFDC-",
         "JAM": "JAM-",
         "Business As Usual": "BAU-",
-        "State Of The States 2019": "SOTS19-"
+        "State of the States 2019": "SOTS19-"
 
       project =
         projectId: reqBody["project"]["id"]

--- a/scripts/pivotal-listener.coffee
+++ b/scripts/pivotal-listener.coffee
@@ -44,7 +44,7 @@ module.exports = (robot) ->
         "Salesforce": "SFDC-",
         "JAM": "JAM-",
         "Business As Usual": "BAU-",
-        "State Of The States 2019": "SOTS-"
+        "State Of The States 2019": "SOTS19-"
 
       project =
         projectId: reqBody["project"]["id"]


### PR DESCRIPTION
changed the prefix for the **State Of The States 2019** pivotal board to SOTS19- so it doesn't conflict with he earlier SOTS prefix. 